### PR TITLE
Fixed incorrect bossBarBlackList config causing infinite toml rewrites.

### DIFF
--- a/src/main/java/top/theillusivec4/champions/common/config/ChampionsConfig.java
+++ b/src/main/java/top/theillusivec4/champions/common/config/ChampionsConfig.java
@@ -354,7 +354,8 @@ public class ChampionsConfig {
         .translation(CONFIG_PREFIX + "showHud").define("showHud", true);
       bossBarBlackList = builder.comment(
           "Set entity id (for example, ['minecraft:end_dragon', 'minecraft:creeper']) to hidden HUD display for champions, including health, affixes, and tier")
-        .translation(CONFIG_PREFIX + "bossBarBlackList").define("bossBarBlackList", List.of(), ChampionsConfig::validateEntityName);
+        .translation(CONFIG_PREFIX + "bossBarBlackList")
+        .defineListAllowEmpty("bossBarBlackList", List.of(), ChampionsConfig::validateEntityName);
 
       showParticles = builder.comment(
           "Set to true to have champions generate a colored particle effect indicating their rank")


### PR DESCRIPTION
The config def for bossBarBlackList isn't defined correctly to be a list that is allowed to be empty. This causes forge to infinitely correct/rewrite the toml config.